### PR TITLE
Use free GitHub arm64 runner in builders.json

### DIFF
--- a/builders.json
+++ b/builders.json
@@ -4,7 +4,7 @@
       "name": "builder-jammy-java-tiny",
       "path": ".",
       "container_repository": "builder-jammy-java-tiny",
-      "test_runners": ["ubuntu-22.04", "buildjet-4vcpu-ubuntu-2204-arm"]
+      "test_runners": ["ubuntu-22.04", "ubuntu-22.04-arm"]
     }
   ]
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Github now provides free arm64 runners. This PR updates the arm64 to the free one provided by GitHub.

https://docs.github.com/en/actions/reference/runners/github-hosted-runners

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
